### PR TITLE
infinite loop occurs when trying to rotate video on Windows

### DIFF
--- a/qtrotate.py
+++ b/qtrotate.py
@@ -155,9 +155,9 @@ def get_set_rotation(infilename, set_degrees=None):
             cos_deg = int((1<<16)*math.cos(radians))
             sin_deg = int((1<<16)*math.sin(radians))
             value = struct.pack(">9l", cos_deg, sin_deg, 0, -sin_deg, cos_deg, 0, 0, 0, (1<<30))
-            datastream.seek(-36, 1)
+            datastream.seek(-value.__len__(), 1)
             datastream.write(value)
-
+            datastream.flush()
         else:        
             for x in range(9):
                 if (x + 1) % 3:

--- a/qtrotate.py
+++ b/qtrotate.py
@@ -155,7 +155,7 @@ def get_set_rotation(infilename, set_degrees=None):
             cos_deg = int((1<<16)*math.cos(radians))
             sin_deg = int((1<<16)*math.sin(radians))
             value = struct.pack(">9l", cos_deg, sin_deg, 0, -sin_deg, cos_deg, 0, 0, 0, (1<<30))
-            datastream.seek(-value.__len__(), 1)
+            datastream.seek(-len(value), 1)
             datastream.write(value)
             datastream.flush()
         else:        


### PR DESCRIPTION
- added datastream.flush. On windows, if you don't do that, python will add null char to your string. This will not happen on Unix based python because datastream.read will "commit" the string into the file. However, on windows, you're required to use flush or close
- rather than assuming that the tkhd value will always be 36 char, use char.**len**() instead
